### PR TITLE
Modified notice css to allow for multiple paragraphs and code embeds

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -526,6 +526,9 @@ blockquote cite {
     color: #666;
     font-size: 1.2rem;
 }
+
+/* notice shortcode */
+
 div.notices {
     margin: 2rem 0;
     position: relative;
@@ -537,6 +540,9 @@ div.notices p {
     margin-top: 0rem;
     margin-bottom: 0rem;
     color: #666;
+}
+div.notices pre {
+    margin: 0 1rem;
 }
 div.notices p:first-child:before {
     position: absolute;
@@ -553,30 +559,38 @@ div.notices p:first-child:after {
     color: #fff;
     left: 2rem;
 }
-div.notices.info p {
-    border-top: 30px solid #F0B37E;
+div.notices.info {
     background: #FFF2DB;
+}
+div.notices.info p:first-child {
+    border-top: 30px solid #F0B37E;
 }
 div.notices.info p:first-child:after {
     content: 'Info';
 }
-div.notices.warning p {
-    border-top: 30px solid rgba(217, 83, 79, 0.8);
+div.notices.warning {
     background: #FAE2E2;
+}
+div.notices.warning p:first-child {
+    border-top: 30px solid rgba(217, 83, 79, 0.8);
 }
 div.notices.warning p:first-child:after {
     content: 'Warning';
 }
-div.notices.note p {
-    border-top: 30px solid #6AB0DE;
+div.notices.note {
     background: #E7F2FA;
+}
+div.notices.note p:first-child {
+    border-top: 30px solid #6AB0DE;
 }
 div.notices.note p:first-child:after {
     content: 'Note';
 }
-div.notices.tip p {
-    border-top: 30px solid rgba(92, 184, 92, 0.8);
+div.notices.tip {
     background: #E6F9E6;
+}
+div.notices.tip p:fist-child {
+    border-top: 30px solid rgba(92, 184, 92, 0.8);
 }
 div.notices.tip p:first-child:after {
     content: 'Tip';


### PR DESCRIPTION
Prior to this change if a notice contained multiple paragraphs, each paragraph had a darker-shade border at the top (where the type of notice appears in the first paragraph), and there was white space between each paragraph.  

This change removes the top border from successive paragraphs (so there is only one on the first) and provides a continuous background color matching the theme  across all child elements.  In addition, it applies a small margin to code embeds that are nested within the notice.  This helps establish that the entire notice is one region.