### PR TITLE
Added link shortcode

### DIFF
--- a/layouts/shortcodes/link.html
+++ b/layouts/shortcodes/link.html
@@ -1,0 +1,5 @@
+{{ if .IsNamedParams }}
+<a href="{{ .Get "url" }}" target="_blank">{{ .Get ".url" }}</a>
+{{ else }}
+<a href="{{ .Get 0 }}" target="_blank">{{ .Get 0 }}</a>
+{{ end }}


### PR DESCRIPTION
The link shortcode allows for external links that open in new tabs.  Usage: {{<link "https://some-site.com/resource">}}